### PR TITLE
Add Virtual LAN support

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -168,6 +168,25 @@
 2015-01-19  Kris Moore <kris@pcbsd.org>
 
 	* grub-core/disk/geli.c: Support GELI v6 and v7.
+=======
+2015-01-23  Paulo Flabiano Smorigo  <pfsmorigo@br.ibm.com>
+
+	Add Virtual LAN support.
+
+	This patch adds support for virtual LAN (VLAN) tagging. VLAN tagging
+	allows multiple VLANs in a bridged network to share the same physical
+	network link but maintain isolation:
+
+	http://en.wikipedia.org/wiki/IEEE_802.1Q
+
+	* grub-core/net/ethernet.c: Add check, get, and set vlan tag id.
+	* grub-core/net/drivers/ieee1275/ofnet.c: Get vlan tag id from
+	bootargs.
+	* grub-core/net/arp.c: Add check.
+	* grub-core/net/ip.c: Likewise.
+	* include/grub/net/arp.h: Add vlantag attribute.
+	* include/grub/net/ip.h: Likewise.
+>>>>>>> Add Virtual LAN support
 
 2014-12-09  Andrei Borzenkov  <arvidjaar@gmail.com>
 

--- a/grub-core/net/arp.c
+++ b/grub-core/net/arp.c
@@ -122,8 +122,8 @@ grub_net_arp_send_request (struct grub_net_network_level_interface *inf,
 }
 
 grub_err_t
-grub_net_arp_receive (struct grub_net_buff *nb,
-		      struct grub_net_card *card)
+grub_net_arp_receive (struct grub_net_buff *nb, struct grub_net_card *card,
+                      grub_uint16_t vlantag_vid)
 {
   struct arphdr *arp_header = (struct arphdr *) nb->data;
   grub_uint8_t *sender_hardware_address;
@@ -158,6 +158,12 @@ grub_net_arp_receive (struct grub_net_buff *nb,
 
   FOR_NET_NETWORK_LEVEL_INTERFACES (inf)
   {
+    /* Check vlantag id */
+    if (inf->card == card &&
+        ((inf->vlantag.set && vlantag_vid != inf->vlantag.vid) ||
+         (!inf->vlantag.set && vlantag_vid != 0)))
+        continue;
+
     /* Am I the protocol address target? */
     if (grub_net_addr_cmp (&inf->address, &target_addr) == 0
 	&& grub_be_to_cpu16 (arp_header->op) == ARP_REQUEST)

--- a/grub-core/net/ethernet.c
+++ b/grub-core/net/ethernet.c
@@ -18,6 +18,7 @@
 
 #include <grub/misc.h>
 #include <grub/mm.h>
+#include <grub/env.h>
 #include <grub/net/ethernet.h>
 #include <grub/net/ip.h>
 #include <grub/net/arp.h>
@@ -56,10 +57,16 @@ send_ethernet_packet (struct grub_net_network_level_interface *inf,
 {
   struct etherhdr *eth;
   grub_err_t err;
+  grub_uint8_t etherhdr_size;
 
-  COMPILE_TIME_ASSERT (sizeof (*eth) < GRUB_NET_MAX_LINK_HEADER_SIZE);
+  etherhdr_size = sizeof (*eth);
+  COMPILE_TIME_ASSERT (sizeof (*eth) + 4 < GRUB_NET_MAX_LINK_HEADER_SIZE);
 
-  err = grub_netbuff_push (nb, sizeof (*eth));
+  /* Increase ethernet header in case of vlantag */
+  if (inf->vlantag.set)
+    etherhdr_size += 4;
+
+  err = grub_netbuff_push (nb, etherhdr_size);
   if (err)
     return err;
   eth = (struct etherhdr *) nb->data;
@@ -76,6 +83,21 @@ send_ethernet_packet (struct grub_net_network_level_interface *inf,
 	return err;
       inf->card->opened = 1;
     }
+
+  /* Check and add a vlan-tag if needed. */
+  if (inf->vlantag.set)
+    {
+      grub_uint32_t vlantag;
+      vlantag = grub_cpu_to_be32 ((VLANTAG_IDENTIFIER << 16) | inf->vlantag.vid);
+
+      /* Move eth type to the right */
+      grub_memcpy ((char *) nb->data + etherhdr_size - 2,
+                   (char *) nb->data + etherhdr_size - 6, 2);
+
+      /* Add the tag in the middle */
+      grub_memcpy ((char *) nb->data + etherhdr_size - 6, &vlantag, 4);
+    }
+
   return inf->card->driver->send (inf->card, nb);
 }
 
@@ -90,10 +112,26 @@ grub_net_recv_ethernet_packet (struct grub_net_buff *nb,
   grub_net_link_level_address_t hwaddress;
   grub_net_link_level_address_t src_hwaddress;
   grub_err_t err;
+  grub_uint8_t etherhdr_size = sizeof (*eth);
+  grub_uint16_t vlantag_vid = 0;
+
+  /* Check if a vlan-tag is present. If so, the ethernet header is 4 bytes */
+  /* longer than the original one. The vlantag id is extracted and the header */
+  /* is reseted to the original size. */
+  if (grub_get_unaligned16 (nb->data + etherhdr_size - 2) ==
+      grub_cpu_to_be16_compile_time (VLANTAG_IDENTIFIER))
+    {
+      vlantag_vid = grub_be_to_cpu16 (grub_get_unaligned16 (nb->data +
+                                                      etherhdr_size)) & 0x1fff;
+      etherhdr_size += 4;
+      /* Move eth type to the original position */
+      grub_memcpy((char *) nb->data + etherhdr_size - 6,
+                  (char *) nb->data + etherhdr_size - 2, 2);
+    }
 
   eth = (struct etherhdr *) nb->data;
   type = grub_be_to_cpu16 (eth->type);
-  err = grub_netbuff_pull (nb, sizeof (*eth));
+  err = grub_netbuff_pull (nb, etherhdr_size);
   if (err)
     return err;
 
@@ -121,13 +159,14 @@ grub_net_recv_ethernet_packet (struct grub_net_buff *nb,
     {
       /* ARP packet. */
     case GRUB_NET_ETHERTYPE_ARP:
-      grub_net_arp_receive (nb, card);
+      grub_net_arp_receive (nb, card, vlantag_vid);
       grub_netbuff_free (nb);
       return GRUB_ERR_NONE;
       /* IP packet.  */
     case GRUB_NET_ETHERTYPE_IP:
     case GRUB_NET_ETHERTYPE_IP6:
-      return grub_net_recv_ip_packets (nb, card, &hwaddress, &src_hwaddress);
+      return grub_net_recv_ip_packets (nb, card, &hwaddress, &src_hwaddress,
+                                       vlantag_vid);
     }
   grub_netbuff_free (nb);
   return GRUB_ERR_NONE;

--- a/include/grub/net.h
+++ b/include/grub/net.h
@@ -268,6 +268,12 @@ typedef struct grub_net
 
 extern grub_net_t (*EXPORT_VAR (grub_net_open)) (const char *name);
 
+struct grub_net_vlantag
+{
+  grub_uint8_t set;
+  grub_uint16_t vid;
+};
+
 struct grub_net_network_level_interface
 {
   struct grub_net_network_level_interface *next;
@@ -279,6 +285,7 @@ struct grub_net_network_level_interface
   grub_net_interface_flags_t flags;
   struct grub_net_bootp_packet *dhcp_ack;
   grub_size_t dhcp_acklen;
+  struct grub_net_vlantag vlantag;
   void *data;
 };
 
@@ -537,5 +544,7 @@ extern char *grub_net_default_server;
 #define GRUB_NET_TRIES 40
 #define GRUB_NET_INTERVAL 400
 #define GRUB_NET_INTERVAL_ADDITION 20
+
+#define VLANTAG_IDENTIFIER 0x8100
 
 #endif /* ! GRUB_NET_HEADER */

--- a/include/grub/net/arp.h
+++ b/include/grub/net/arp.h
@@ -22,10 +22,11 @@
 #include <grub/net.h>
 
 extern grub_err_t grub_net_arp_receive (struct grub_net_buff *nb,
-					struct grub_net_card *card);
+                                        struct grub_net_card *card,
+                                        grub_uint16_t vlantag_vid);
 
 grub_err_t
 grub_net_arp_send_request (struct grub_net_network_level_interface *inf,
-			   const grub_net_network_level_address_t *proto_addr);
+                           const grub_net_network_level_address_t *proto_addr);
 
 #endif 

--- a/include/grub/net/ip.h
+++ b/include/grub/net/ip.h
@@ -48,7 +48,8 @@ grub_err_t
 grub_net_recv_ip_packets (struct grub_net_buff *nb,
 			  struct grub_net_card *card,
 			  const grub_net_link_level_address_t *hwaddress,
-			  const grub_net_link_level_address_t *src_hwaddress);
+			  const grub_net_link_level_address_t *src_hwaddress,
+                          grub_uint16_t vlantag_vid);
 
 grub_err_t
 grub_net_send_ip_packet (struct grub_net_network_level_interface *inf,


### PR DESCRIPTION
This patch adds support for virtual LAN (VLAN) tagging. VLAN tagging allows multiple VLANs in a bridged network to share the same physical network link but maintain isolation:

http://en.wikipedia.org/wiki/IEEE_802.1Q

* grub-core/net/ethernet.c: Add check, get, and set vlan tag id.
* grub-core/net/drivers/ieee1275/ofnet.c: Get vlan tag id from bootargs.
* grub-core/net/arp.c: Add check.
* grub-core/net/ip.c: Likewise.
* include/grub/net/arp.h: Add vlantag attribute.
* include/grub/net/ip.h: Likewise.